### PR TITLE
Filtered main list of knowledge maps

### DIFF
--- a/app/js/maps.js
+++ b/app/js/maps.js
@@ -69,6 +69,7 @@ service('getMap', function(Map, Resource, Concept, fetchMap,
 
 controller('MapsCtrl', function($scope) {
     new Parse.Query('Map')
+        .equalTo('owner', undefined)
         .find()
     .then(function(maps) {
         $scope.maps = maps;


### PR DESCRIPTION
Now only maps without an owner can be seen on the main knowledge maps list
This change was neccessary as a consequence of #56
