### PR TITLE
Work around the graph disappearing issue

### DIFF
--- a/app/templates/map-header.html
+++ b/app/templates/map-header.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-    <a ng-href="{{makeURL(map)}}">
+    <a ng-click="setView()" style="cursor: pointer;">
         <h1 ng-bind="map.attributes.title"></h1>
     </a>
     <button class="btn" ng-class="{'btn-primary': editMode, 'btn-default': !editMode}"

--- a/app/templates/map-progress.html
+++ b/app/templates/map-progress.html
@@ -1,8 +1,8 @@
 <div class="understanding progress progress-vertical">
     <a ng-repeat="resource in resources"
-       ng-href="{{ makeURL(map, resource) }}"
+       ng-click="setView()"
        class="progress-bar {{ resource.understanding() | result | understandingClass }}"
        ng-class="{current: resource.id == $parent.resource.id}"
-       style="height: {{ 100/resources.length }}%;">
+       style="cursor: pointer; height: {{ 100/resources.length }}%;">
     </a>
 </div>


### PR DESCRIPTION
Instead of using native hyperlinks, the map title and bookmarks now call `setView()`, which stops the graph from disappearing.
