### PR TITLE
Don't re-render the graph every time visibility changes

### DIFF
--- a/app/js/components.js
+++ b/app/js/components.js
@@ -462,7 +462,6 @@ directive('knowledgeMap', function() {
             // rendered properly while it was off-screen.
             scope.$watch('visible', function(value, old) {
                 if(value && !old && km) {
-                    km.unhold().render();
                     if(scope.focus) {
                         km.panTo('n'+scope.focus);
                         km.highlightEdges('n'+scope.focus);


### PR DESCRIPTION
This is a good idea because layout might become expensive.
