### PR TITLE
Use base width for rect size and positioning calculations

### DIFF
--- a/app/js/components.js
+++ b/app/js/components.js
@@ -308,11 +308,11 @@ directive('knowledgeMap', function() {
                 km.renderNodes.onUpdate(function(nodes) {
                     nodes.filter('.concept').select('rect')
                         // Offset rects so they're centred.
-                        .attr('x', function(d) { return -d.width/2 - 5; })
-                        .attr('y', function(d) { return -d.height/2 - 3; })
+                        .attr('x', function(d) { return -d.baseWidth/2 - 5; })
+                        .attr('y', function(d) { return -d.baseHeight/2 - 3; })
                         // Add a bit of padding.
-                        .attr('width', function(d) { return d.width + 10; })
-                        .attr('height', function(d) { return d.height + 6; })
+                        .attr('width', function(d) { return d.baseWidth + 10; })
+                        .attr('height', function(d) { return d.baseHeight + 6; })
                         // Round corners.
                         .attr('rx', '0.25em').attr('ry', '0.25em');
                 })

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "cartographer": "knowledge-map/cartographer#v0.1.0",
+    "cartographer": "knowledge-map/cartographer#v0.1.1",
     "angular": "1.2.x",
     "angular-route": "1.2.x",
     "Flat-UI": "~2.1.3",


### PR DESCRIPTION
This is a new update in `cartographer` which provides `baseWidth` and `baseHeight`, which are constants for a given node (they're based on its `text` element, so they're not changed by stuff you add to the node).
