### PR TITLE
Fix autocomplete when entering concepts for a resource

### DIFF
--- a/app/js/components.js
+++ b/app/js/components.js
@@ -217,6 +217,7 @@ directive('resourceConceptTags', function(Concept, makeURL) {
             resource: '=',
             map: '=',
             editMode: '=',
+            concepts: '=',
         },
         link: function(scope, elem, attrs) {
             scope.makeURL = makeURL;

--- a/app/templates/resource.html
+++ b/app/templates/resource.html
@@ -9,7 +9,7 @@
             <p class="text-center">
                 <resource-read resource="resource" map="map" size="large"></resource-read>
             </p>
-            <resource-concept-tags resource="resource" map="map" edit-mode="editMode"></resource-concept-tags>
+            <resource-concept-tags concepts="concepts" resource="resource" map="map" edit-mode="editMode"></resource-concept-tags>
         </div>
     </div>
     <loading status="status" ng-switch-default></loading>


### PR DESCRIPTION
The problem was that the list of concepts wasn't being passed to the conceptTags directive.
